### PR TITLE
feat:  add publishConfig and include @profusion in package names

### DIFF
--- a/projects/ngx-fetcher-with-etag/package.json
+++ b/projects/ngx-fetcher-with-etag/package.json
@@ -8,5 +8,8 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/projects/ngx-json-schema-forms/package.json
+++ b/projects/ngx-json-schema-forms/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngx-json-schema-forms",
+  "name": "@profusion/ngx-json-schema-forms",
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^19.2.0",

--- a/projects/ngx-json-schema-forms/package.json
+++ b/projects/ngx-json-schema-forms/package.json
@@ -9,5 +9,8 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

- Add `publishConfig` in all libraries:  Makes the package publicly available on the registry. This is required for scoped packages that are intended to be public.
- Update ngx-json-schema-forms name to include @profusion: necessary for us to publish the package to the organization
